### PR TITLE
Menu bar on alt backslash

### DIFF
--- a/main.js
+++ b/main.js
@@ -1,5 +1,5 @@
 const { app, BrowserWindow, shell } = require("electron");
-const { registerMenuHandling, toggleMenuBar } = require("./menuBarHandling");
+const { registerMenuHandling } = require("./menuBarHandling");
 
 app.on("ready", () => {
   const win = new BrowserWindow({

--- a/main.js
+++ b/main.js
@@ -1,4 +1,5 @@
 const { app, BrowserWindow, shell } = require("electron");
+const { registerMenuHandling, toggleMenuBar } = require("./menuBarHandling");
 
 app.on("ready", () => {
   const win = new BrowserWindow({
@@ -9,6 +10,8 @@ app.on("ready", () => {
   });
   win.maximize();
   win.loadURL("https://notion.so");
+
+  registerMenuHandling(win);
 
   // Deal with external links
   win.webContents.setWindowOpenHandler(({ url }) => {

--- a/menuBarHandling.js
+++ b/menuBarHandling.js
@@ -42,4 +42,4 @@ function registerMenuHandling(win) {
   }
 }
 
-module.exports = { registerMenuHandling, toggleMenuBar };
+module.exports = { registerMenuHandling };

--- a/menuBarHandling.js
+++ b/menuBarHandling.js
@@ -1,0 +1,45 @@
+const { globalShortcut, Menu, MenuItem } = require("electron");
+
+let isMenuOnAltBackslash = false;
+
+function toggleMenuBar(win) {
+  const isMenuBarVisible = win.autoHideMenuBar;
+  win.setAutoHideMenuBar(!isMenuBarVisible);
+  win.setMenuBarVisibility(isMenuBarVisible);
+}
+
+function registerMenuHandling(win) {
+  // Menu bar toggling shortcut register
+  const menuShortcut = globalShortcut.register("Alt+\\", () => {
+    toggleMenuBar(win);
+  });
+
+  if (!menuShortcut) {
+    console.error("Failed to register global shortcut!");
+  }
+
+  // Preventing menu bar toggling on Alt
+  win.webContents.on("before-input-event", (event, input) => {
+    if (isMenuOnAltBackslash && input.alt) {
+      event.preventDefault();
+    }
+  });
+
+  // Adding menu item to the "Window" menu
+  const menu = Menu.getApplicationMenu();
+  const windowMenu = menu.items?.find((el) => el.role === "windowmenu");
+  if (windowMenu) {
+    windowMenu.submenu.insert(0, new MenuItem({
+      label: "Open menu bar on ALT+\\",
+      type: 'checkbox',
+      checked: isMenuOnAltBackslash,
+      click: () => {
+        isMenuOnAltBackslash = !isMenuOnAltBackslash;
+        win.setAutoHideMenuBar(true);
+        win.setMenuBarVisibility(false);
+      }
+    }));
+  }
+}
+
+module.exports = { registerMenuHandling, toggleMenuBar };

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "notion-snap-reborn",
-  "version": "1.0.24",
+  "version": "1.0.25",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "notion-snap-reborn",
-      "version": "1.0.24",
+      "version": "1.0.25",
       "license": "ISC",
       "devDependencies": {
         "electron": "27.1.3",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "notion-snap-reborn",
-  "version": "1.0.25",
+  "version": "1.0.26",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "notion-snap-reborn",
-      "version": "1.0.25",
+      "version": "1.0.26",
       "license": "ISC",
       "devDependencies": {
         "electron": "28.0.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "notion-snap-reborn",
-  "version": "1.0.16",
+  "version": "1.0.17",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "notion-snap-reborn",
-      "version": "1.0.16",
+      "version": "1.0.17",
       "license": "ISC",
       "devDependencies": {
         "electron": "26.3.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "notion-snap-reborn",
-  "version": "1.0.15",
+  "version": "1.0.16",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "notion-snap-reborn",
-      "version": "1.0.15",
+      "version": "1.0.16",
       "license": "ISC",
       "devDependencies": {
         "electron": "26.2.4",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "notion-snap-reborn",
-  "version": "1.0.20",
+  "version": "1.0.21",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "notion-snap-reborn",
-      "version": "1.0.20",
+      "version": "1.0.21",
       "license": "ISC",
       "devDependencies": {
         "electron": "27.0.4",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "notion-snap-reborn",
-  "version": "1.0.23",
+  "version": "1.0.24",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "notion-snap-reborn",
-      "version": "1.0.23",
+      "version": "1.0.24",
       "license": "ISC",
       "devDependencies": {
         "electron": "27.1.2",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "notion-snap-reborn",
-  "version": "1.0.19",
+  "version": "1.0.20",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "notion-snap-reborn",
-      "version": "1.0.19",
+      "version": "1.0.20",
       "license": "ISC",
       "devDependencies": {
         "electron": "27.0.3",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "notion-snap-reborn",
-  "version": "1.0.22",
+  "version": "1.0.23",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "notion-snap-reborn",
-      "version": "1.0.22",
+      "version": "1.0.23",
       "license": "ISC",
       "devDependencies": {
         "electron": "27.1.2",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "notion-snap-reborn",
-  "version": "1.0.14",
+  "version": "1.0.15",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "notion-snap-reborn",
-      "version": "1.0.14",
+      "version": "1.0.15",
       "license": "ISC",
       "devDependencies": {
         "electron": "26.2.3",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "notion-snap-reborn",
-  "version": "1.0.17",
+  "version": "1.0.18",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "notion-snap-reborn",
-      "version": "1.0.17",
+      "version": "1.0.18",
       "license": "ISC",
       "devDependencies": {
         "electron": "27.0.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "notion-snap-reborn",
-  "version": "1.0.18",
+  "version": "1.0.19",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "notion-snap-reborn",
-      "version": "1.0.18",
+      "version": "1.0.19",
       "license": "ISC",
       "devDependencies": {
         "electron": "27.0.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "notion-snap-reborn",
-  "version": "1.0.13",
+  "version": "1.0.14",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "notion-snap-reborn",
-      "version": "1.0.13",
+      "version": "1.0.14",
       "license": "ISC",
       "devDependencies": {
         "electron": "26.2.2",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "notion-snap-reborn",
-  "version": "1.0.11",
+  "version": "1.0.12",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "notion-snap-reborn",
-      "version": "1.0.11",
+      "version": "1.0.12",
       "license": "ISC",
       "devDependencies": {
         "electron": "26.2.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "notion-snap-reborn",
-  "version": "1.0.21",
+  "version": "1.0.22",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "notion-snap-reborn",
-      "version": "1.0.21",
+      "version": "1.0.22",
       "license": "ISC",
       "devDependencies": {
         "electron": "27.1.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "notion-snap-reborn",
-  "version": "1.0.12",
+  "version": "1.0.13",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "notion-snap-reborn",
-      "version": "1.0.12",
+      "version": "1.0.13",
       "license": "ISC",
       "devDependencies": {
         "electron": "26.2.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "notion-snap-reborn",
-  "version": "1.0.20",
+  "version": "1.0.21",
   "description": "A snap of Notion",
   "main": "main.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "notion-snap-reborn",
-  "version": "1.0.23",
+  "version": "1.0.24",
   "description": "A snap of Notion",
   "main": "main.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "notion-snap-reborn",
-  "version": "1.0.17",
+  "version": "1.0.18",
   "description": "A snap of Notion",
   "main": "main.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "notion-snap-reborn",
-  "version": "1.0.13",
+  "version": "1.0.14",
   "description": "A snap of Notion",
   "main": "main.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "notion-snap-reborn",
-  "version": "1.0.19",
+  "version": "1.0.20",
   "description": "A snap of Notion",
   "main": "main.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "notion-snap-reborn",
-  "version": "1.0.21",
+  "version": "1.0.22",
   "description": "A snap of Notion",
   "main": "main.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "notion-snap-reborn",
-  "version": "1.0.15",
+  "version": "1.0.16",
   "description": "A snap of Notion",
   "main": "main.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "notion-snap-reborn",
-  "version": "1.0.25",
+  "version": "1.0.26",
   "description": "A snap of Notion",
   "main": "main.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "notion-snap-reborn",
-  "version": "1.0.16",
+  "version": "1.0.17",
   "description": "A snap of Notion",
   "main": "main.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "notion-snap-reborn",
-  "version": "1.0.18",
+  "version": "1.0.19",
   "description": "A snap of Notion",
   "main": "main.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "notion-snap-reborn",
-  "version": "1.0.12",
+  "version": "1.0.13",
   "description": "A snap of Notion",
   "main": "main.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "notion-snap-reborn",
-  "version": "1.0.14",
+  "version": "1.0.15",
   "description": "A snap of Notion",
   "main": "main.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "notion-snap-reborn",
-  "version": "1.0.24",
+  "version": "1.0.25",
   "description": "A snap of Notion",
   "main": "main.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "notion-snap-reborn",
-  "version": "1.0.11",
+  "version": "1.0.12",
   "description": "A snap of Notion",
   "main": "main.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "notion-snap-reborn",
-  "version": "1.0.22",
+  "version": "1.0.23",
   "description": "A snap of Notion",
   "main": "main.js",
   "scripts": {


### PR DESCRIPTION
Hello, thank you for your snap!
I've added a toggle to the menu bar to open menu bar only on Alt+\ instead of just Alt.
It's very annoying when you have some important global shortcuts (Alt+Shift for keyboard layout changing, for example, which is very common). And this menu bar appears all the time and blocks everything when you don't expect it.
Would be great to see this option in your snap. Thank you!